### PR TITLE
Add subtract

### DIFF
--- a/opencv/cxcore.go
+++ b/opencv/cxcore.go
@@ -526,6 +526,91 @@ func AbsDiff(src1, src2, dst *IplImage) {
 *                                Math operations                              *
 \****************************************************************************************/
 
+// Calculates the per-element sum of two arrays.
+//   dst = src1 + src2
+func Add(src1, src2, dst *IplImage) {
+	AddWithMask(src1, src2, dst, nil)
+}
+
+// Calculates the per-element sum of two arrays with a mask.
+//   dst = src1 + src2
+func AddWithMask(src1, src2, dst, mask *IplImage) {
+	C.cvAdd(
+		unsafe.Pointer(src1),
+		unsafe.Pointer(src2),
+		unsafe.Pointer(dst),
+		unsafe.Pointer(mask),
+	)
+}
+
+// Calculates the per-element sum of an array and a scalar.
+//   dst = src + value
+func AddScalar(src *IplImage, value Scalar, dst *IplImage) {
+	AddScalarWithMask(src, value, dst, nil)
+}
+
+// Calculates the per-element sum of an array and a scalar with a mask.
+//   dst = src + value
+func AddScalarWithMask(src *IplImage, value Scalar, dst, mask *IplImage) {
+	C.cvAddS(
+		unsafe.Pointer(src),
+		(C.CvScalar)(value),
+		unsafe.Pointer(dst),
+		unsafe.Pointer(mask),
+	)
+}
+
+// Calculates the per-element difference between two arrays.
+//   dst = src1 - src2
+func Subtract(src1, src2, dst *IplImage) {
+	SubtractWithMask(src1, src2, dst, nil)
+}
+
+// Calculates the per-element difference between two arrays with a mask.
+//   dst = src1 - src2
+func SubtractWithMask(src1, src2, dst, mask *IplImage) {
+	C.cvSub(
+		unsafe.Pointer(src1),
+		unsafe.Pointer(src2),
+		unsafe.Pointer(dst),
+		unsafe.Pointer(mask),
+	)
+}
+
+// Calculates the per-element difference between an array and a scalar.
+//   dst = src - value
+func SubScalar(src *IplImage, value Scalar, dst *IplImage) {
+	SubScalarWithMask(src, value, dst, nil)
+}
+
+// Calculates the per-element difference between an array and a scalar with a mask.
+//   dst = src - value
+func SubScalarWithMask(src *IplImage, value Scalar, dst, mask *IplImage) {
+	C.cvSubS(
+		unsafe.Pointer(src),
+		(C.CvScalar)(value),
+		unsafe.Pointer(dst),
+		unsafe.Pointer(mask),
+	)
+}
+
+// Calculates the per-element difference between a scalar and an array.
+//   dst = value - src
+func SubScalarRev(value Scalar, src, dst *IplImage) {
+	SubScalarWithMaskRev(value, src, dst, nil)
+}
+
+// Calculates the per-element difference between a scalar and an array with a mask.
+//   dst = value - src
+func SubScalarWithMaskRev(value Scalar, src, dst, mask *IplImage) {
+	C.cvSubRS(
+		unsafe.Pointer(src),
+		(C.CvScalar)(value),
+		unsafe.Pointer(dst),
+		unsafe.Pointer(mask),
+	)
+}
+
 /****************************************************************************************\
 *                                Matrix operations                            *
 \****************************************************************************************/

--- a/opencv/cxcore_test.go
+++ b/opencv/cxcore_test.go
@@ -3,12 +3,20 @@ package opencv
 import (
 	"bytes"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path"
 	"runtime"
 	"syscall"
 	"testing"
+	"time"
 )
+
+func init() {
+	// seed random number generator for
+	// creating random mask for TestAddSubWithMask below
+	rand.Seed(time.Now().Unix())
+}
 
 func TestLoadImage2(t *testing.T) {
 	// t.Errorf("aaa")
@@ -120,52 +128,122 @@ func TestAbsDiff(t *testing.T) {
 }
 
 func TestAddSub(t *testing.T) {
-
+	w, h := 50, 50
 	checkVals := func(img *IplImage, val float64, debug string) {
-	loop:
-		for j := 0; j < img.Height(); j++ {
-			for i := 0; i < img.Width(); i++ {
-				pix := img.Get2D(i, j).Val()
-				if pix[0] != val || pix[1] != val || pix[2] != val {
-					t.Errorf("Unexpeted value for %s: %.1f, %.1f, %.1f. Expected %.1fs",
-						debug, pix[0], pix[1], pix[2], val)
-					break loop
-				}
+		for i := 0; i < w*h; i++ {
+			pix := img.Get1D(i).Val()
+			if pix[0] != val || pix[1] != val || pix[2] != val {
+				t.Errorf("Unexpeted value for %s: %.1f, %.1f, %.1f. Expected %.1fs",
+					debug, pix[0], pix[1], pix[2], val)
+				break
 			}
 		}
 	}
 
-	zeroImg := CreateImage(50, 50, IPL_DEPTH_8U, 3)
+	zeroImg := CreateImage(w, h, IPL_DEPTH_8U, 3)
 	zeroImg.Zero()
 
-	twosImg := zeroImg.Clone()
-	foursImg := zeroImg.Clone()
-	negTwosImg := zeroImg.Clone()
+	hundredImg := zeroImg.Clone()
+	twoHundredImg := zeroImg.Clone()
+	negImage := zeroImg.Clone()
 	defer zeroImg.Release()
-	defer twosImg.Release()
-	defer foursImg.Release()
-	defer negTwosImg.Release()
+	defer hundredImg.Release()
+	defer twoHundredImg.Release()
+	defer negImage.Release()
 
-	two := NewScalar(2, 2, 2, 2)
+	hundred := NewScalar(100, 100, 100, 0)
 
-	// 0 + 2 = 2
-	AddScalar(zeroImg, two, twosImg)
-	checkVals(twosImg, 2, "AddScalar()")
+	// 0 + 100 = 100
+	AddScalar(zeroImg, hundred, hundredImg)
+	checkVals(hundredImg, 100, "AddScalar()")
 
-	// 2 + 2 = 4
-	Add(twosImg, twosImg, foursImg)
-	checkVals(foursImg, 4, "Add()")
+	// 100 + 100 = 200
+	Add(hundredImg, hundredImg, twoHundredImg)
+	checkVals(twoHundredImg, 200, "Add()")
 
-	// 4 - 2 = 2
-	Subtract(foursImg, twosImg, twosImg)
-	checkVals(twosImg, 2, "Sub()")
+	// 200 - 100 = 100
+	Subtract(twoHundredImg, hundredImg, hundredImg)
+	checkVals(hundredImg, 100, "Sub()")
 
-	// 2 - 2 = 0
-	SubScalar(twosImg, two, zeroImg)
+	// 100 - 100 = 0
+	SubScalar(hundredImg, hundred, zeroImg)
 	checkVals(zeroImg, 0, "SubScalar()")
 
-	// 2 - 4 = 0 != -2 because it clips
-	SubScalarRev(two, foursImg, negTwosImg)
-	checkVals(negTwosImg, 0, "SubScalarRev()")
+	// 100 - 200 = 0 != -100 because it clips
+	SubScalarRev(hundred, twoHundredImg, negImage)
+	checkVals(negImage, 0, "SubScalarRev()")
+
+	// Uncomment to save these images to disk
+	// SaveImage("zeroImg.png", zeroImg, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("hundredImg.png", hundredImg, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("twoHundredImg.png", twoHundredImg, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("negImage.png", negImage, CV_IMWRITE_PNG_COMPRESSION)
+
+}
+
+func TestAddSubWithMask(t *testing.T) {
+	w, h := 50, 50
+	checkValsWMask := func(img, mask *IplImage, val float64, debug string) {
+		for i := 0; i < w*h; i++ {
+			pix := img.Get1D(i).Val()
+			tst := val
+			if mask.Get1D(i).Val()[0] == 0 {
+				tst = 0
+			}
+			if pix[0] != tst || pix[1] != tst || pix[2] != tst {
+				t.Errorf("Unexpeted value for %s: %.1f, %.1f, %.1f. Expected %.1fs",
+					debug, pix[0], pix[1], pix[2], val)
+				break
+			}
+		}
+	}
+
+	zeroImg := CreateImage(w, h, IPL_DEPTH_8U, 3)
+	zeroImg.Zero()
+
+	hundredImg := zeroImg.Clone()
+	twoHundredImg := zeroImg.Clone()
+	negImage := zeroImg.Clone()
+	defer zeroImg.Release()
+	defer hundredImg.Release()
+	defer twoHundredImg.Release()
+	defer negImage.Release()
+
+	// generate a random mask
+	maskImg := CreateImage(w, h, IPL_DEPTH_8U, 1)
+	defer maskImg.Release()
+	for i := 0; i < w*h; i++ {
+		oneOrZero := float64(rand.Intn(2)) // random number either 1 or 0
+		maskImg.Set1D(i, NewScalar(oneOrZero*255, 0, 0, 0))
+	}
+
+	hundred := NewScalar(100, 100, 100, 0)
+
+	// 0 + 100 = 100
+	AddScalarWithMask(zeroImg, hundred, hundredImg, maskImg)
+	checkValsWMask(hundredImg, maskImg, 100, "AddScalarWithMask()")
+
+	// 100 + 100 = 200
+	AddWithMask(hundredImg, hundredImg, twoHundredImg, maskImg)
+	checkValsWMask(twoHundredImg, maskImg, 200, "AddWithMask()")
+
+	// 200 - 100 = 100
+	SubtractWithMask(twoHundredImg, hundredImg, hundredImg, maskImg)
+	checkValsWMask(hundredImg, maskImg, 100, "SubtractWithMask()")
+
+	// 100 - 100 = 0
+	SubScalarWithMask(hundredImg, hundred, zeroImg, maskImg)
+	checkValsWMask(zeroImg, maskImg, 0, "SubScalarWithMask()")
+
+	// 100 - 200 = 0 != -100 because it clips
+	SubScalarWithMaskRev(hundred, twoHundredImg, negImage, maskImg)
+	checkValsWMask(negImage, maskImg, 0, "SubScalarWithMaskRev()")
+
+	// Uncomment to save these images to disk
+	// SaveImage("zeroImgMask.png", zeroImg, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("hundredImgMask.png", hundredImg, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("twoHundredImgMask.png", twoHundredImg, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("negImageMask.png", negImage, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("MaskImg.png", maskImg, CV_IMWRITE_PNG_COMPRESSION)
 
 }

--- a/opencv/cxcore_test.go
+++ b/opencv/cxcore_test.go
@@ -118,3 +118,54 @@ func TestAbsDiff(t *testing.T) {
 		t.Error("Unexpected result for AbsDiff")
 	}
 }
+
+func TestAddSub(t *testing.T) {
+
+	checkVals := func(img *IplImage, val float64, debug string) {
+	loop:
+		for j := 0; j < img.Height(); j++ {
+			for i := 0; i < img.Width(); i++ {
+				pix := img.Get2D(i, j).Val()
+				if pix[0] != val || pix[1] != val || pix[2] != val {
+					t.Errorf("Unexpeted value for %s: %.1f, %.1f, %.1f. Expected %.1fs",
+						debug, pix[0], pix[1], pix[2], val)
+					break loop
+				}
+			}
+		}
+	}
+
+	zeroImg := CreateImage(50, 50, IPL_DEPTH_8U, 3)
+	zeroImg.Zero()
+
+	twosImg := zeroImg.Clone()
+	foursImg := zeroImg.Clone()
+	negTwosImg := zeroImg.Clone()
+	defer zeroImg.Release()
+	defer twosImg.Release()
+	defer foursImg.Release()
+	defer negTwosImg.Release()
+
+	two := NewScalar(2, 2, 2, 2)
+
+	// 0 + 2 = 2
+	AddScalar(zeroImg, two, twosImg)
+	checkVals(twosImg, 2, "AddScalar()")
+
+	// 2 + 2 = 4
+	Add(twosImg, twosImg, foursImg)
+	checkVals(foursImg, 4, "Add()")
+
+	// 4 - 2 = 2
+	Subtract(foursImg, twosImg, twosImg)
+	checkVals(twosImg, 2, "Sub()")
+
+	// 2 - 2 = 0
+	SubScalar(twosImg, two, zeroImg)
+	checkVals(zeroImg, 0, "SubScalar()")
+
+	// 2 - 4 = 0 != -2 because it clips
+	SubScalarRev(two, foursImg, negTwosImg)
+	checkVals(negTwosImg, 0, "SubScalarRev()")
+
+}


### PR DESCRIPTION
Implemented the following C APIs:
- cvAdd() - Adds two arrays (or images)
- cvAddS() - Adds an array plus a scalar
- cvSub() - Subtracts two arrays
- cvSubS() - Subtracts an array by a scalar
- cvSubRS() - Subtracts a scalar by an array

These functions allow for an optional mask and I created two golang calls for each one.
The default opencv.Add() opencv.Subtract(), etc. which doesn't use a mask.  And then separate functions opencv.AddWithMask(), opencv.SubWithMask() that does use the masks.

I also added tests for each call with and without masks.