### PR TITLE
Point helpers

### DIFF
--- a/opencv/cxcore_test.go
+++ b/opencv/cxcore_test.go
@@ -425,3 +425,76 @@ func TestPointRadiusAngleHelpers(t *testing.T) {
 		)
 	}
 }
+
+func TestPointAddSub(t *testing.T) {
+
+	// test Point.Add
+	p1 := Point{0, 1}
+	p1.Add(Point{1, 1})
+	if p1.X != 1 || p1.Y != 2 {
+		t.Error("Unexpected result from Point.Add()")
+	}
+
+	// test Point.Sub
+	p2 := Point{0, 1}
+	p2.Sub(Point{1, 1})
+	if p2.X != -1 || p2.Y != 0 {
+		t.Error("Unexpected result from Point.Sub()")
+	}
+
+	// test Point2D32f.Add
+	p3 := Point2D32f{0, 1}
+	p3.Add(Point2D32f{1, 1})
+	if p3.X != 1 || p3.Y != 2 {
+		t.Error("Unexpected result from Point2D32f.Add()")
+	}
+
+	// test Point2D32f.Sub
+	p4 := Point2D32f{0, 1}
+	p4.Sub(Point2D32f{1, 1})
+	if p4.X != -1 || p4.Y != 0 {
+		t.Error("Unexpected result from Point2D32f.Sub()")
+	}
+
+	// test Point2D64f.Add
+	p5 := Point2D64f{0, 1}
+	p5.Add(Point2D64f{1, 1})
+	if p5.X != 1 || p5.Y != 2 {
+		t.Error("Unexpected result from Point2D64f.Add()")
+	}
+
+	// test Point2D64f.Sub
+	p6 := Point2D64f{0, 1}
+	p6.Sub(Point2D64f{1, 1})
+	if p6.X != -1 || p6.Y != 0 {
+		t.Error("Unexpected result from Point2D64f.Sub()")
+	}
+
+	// test Point3D32f.Add
+	p7 := Point3D32f{0, 1, 2}
+	p7.Add(Point3D32f{1, 1, 3})
+	if p7.X != 1 || p7.Y != 2 || p7.Z != 5 {
+		t.Error("Unexpected result from Point3D32f.Add()")
+	}
+
+	// test Point3D32f.Sub
+	p8 := Point3D32f{0, 1, 2}
+	p8.Sub(Point3D32f{1, 1, 3})
+	if p8.X != -1 || p8.Y != 0 || p8.Z != -1 {
+		t.Error("Unexpected result from Point3D32f.Sub()")
+	}
+
+	// test Point3D64f.Add
+	p9 := Point3D64f{0, 1, 2}
+	p9.Add(Point3D64f{1, 1, 3})
+	if p9.X != 1 || p9.Y != 2 || p9.Z != 5 {
+		t.Error("Unexpected result from Point3D64f.Add()")
+	}
+
+	// test Point3D64f.Sub
+	p10 := Point3D64f{0, 1, 2}
+	p10.Sub(Point3D64f{1, 1, 3})
+	if p10.X != -1 || p10.Y != 0 || p10.Z != -1 {
+		t.Error("Unexpected result from Point3D64f.Sub()")
+	}
+}

--- a/opencv/cxcore_test.go
+++ b/opencv/cxcore_test.go
@@ -351,78 +351,85 @@ func TestLogic(t *testing.T) {
 func TestPointRadiusAngleHelpers(t *testing.T) {
 
 	// test Point
-	testPoint := func(p PointIntrfc, rad, az, inc float64) {
+	test2D := func(p Point2D, rad, az float64) {
 		if p.Radius() != rad {
 			t.Errorf("%v, Radius() Fail: Expected: %f, Received: %f", p, rad, p.Radius())
 		}
 		if p.Angle() != az {
 			t.Errorf("%v, Angle() Fail: Expected: %f, Received: %f", p, az, p.Angle())
 		}
+	}
+
+	test3D := func(p Point3D, rad, az, inc float64) {
+		if p.Radius() != rad {
+			t.Errorf("%v, Radius() Fail: Expected: %f, Received: %f", p, rad, p.Radius())
+		}
+		if p.AzAngle() != az {
+			t.Errorf("%v, Angle() Fail: Expected: %f, Received: %f", p, az, p.AzAngle())
+		}
 		if p.IncAngle() != inc {
 			t.Errorf("%v, IncAngle() Fail: Expected: %f, Received: %f", p, inc, p.IncAngle())
 		}
 	}
 
-	zeroOneTests := []PointIntrfc{
+	// Test Point: {0,1,0}
+	zeroOne2DTests := []Point2D{
 		Point{0, 1},
 		Point2D32f{0, 1},
 		Point2D64f{0, 1},
+	}
+	zeroOne3DTests := []Point3D{
 		Point3D32f{0, 1, 0},
 		Point3D64f{0, 1, 0},
 	}
-
-	for _, zeroOne := range zeroOneTests {
-		testPoint(
-			zeroOne,
-			1,         // radius should be 1
-			math.Pi/2, // angle should be pi/2
-			math.Pi/2, // inc angle should also be pi/2
-		)
+	for _, zeroOne := range zeroOne2DTests {
+		test2D(zeroOne, 1, math.Pi/2)
+	}
+	for _, zeroOne := range zeroOne3DTests {
+		test3D(zeroOne, 1, math.Pi/2, math.Pi/2)
 	}
 
-	fiveFiveTests := []PointIntrfc{
+	// Test Point: {5,5,0}
+	fiveFive2DTests := []Point2D{
 		Point{5, 5},
 		Point2D32f{5, 5},
 		Point2D64f{5, 5},
+	}
+	fiveFive3DTests := []Point3D{
 		Point3D32f{5, 5, 0},
 		Point3D64f{5, 5, 0},
 	}
-	for _, fiveFive := range fiveFiveTests {
-		testPoint(
-			fiveFive,
-			math.Sqrt(50), // radius
-			math.Pi/4,     // angle
-			math.Pi/2,     // inc angle
-		)
+	for _, fiveFive := range fiveFive2DTests {
+		test2D(fiveFive, math.Sqrt(50), math.Pi/4)
+	}
+	for _, fiveFive := range fiveFive3DTests {
+		test3D(fiveFive, math.Sqrt(50), math.Pi/4, math.Pi/2)
 	}
 
-	negThreeFourTests := []PointIntrfc{
+	// Test Point: {-3,4,0}
+	negThreeFour2DTests := []Point2D{
 		Point{-3, 4},
 		Point2D32f{-3, 4},
 		Point2D64f{-3, 4},
+	}
+	negThreeFour3DTests := []Point3D{
 		Point3D32f{-3, 4, 0},
 		Point3D64f{-3, 4, 0},
 	}
-	for _, negThreeFour := range negThreeFourTests {
-		testPoint(
-			negThreeFour,
-			5, // radius
-			math.Pi-math.Atan(4.0/3.0), // az angle
-			math.Pi/2,                  // inc angle
-		)
+	for _, negThreeFour := range negThreeFour2DTests {
+		test2D(negThreeFour, 5, math.Pi-math.Atan(4.0/3.0))
+	}
+	for _, negThreeFour := range negThreeFour3DTests {
+		test3D(negThreeFour, 5, math.Pi-math.Atan(4.0/3.0), math.Pi/2)
 	}
 
-	oneOneOneTests := []PointIntrfc{
+	// Test Point: {1,1,1}
+	oneOneOneTests := []Point3D{
 		Point3D32f{1, 1, 1},
 		Point3D64f{1, 1, 1},
 	}
 	for _, oneoneone := range oneOneOneTests {
-		testPoint(
-			oneoneone,
-			math.Sqrt(3),              // radius
-			math.Pi/4,                 // az angle
-			math.Acos(1/math.Sqrt(3)), // inc angle
-		)
+		test3D(oneoneone, math.Sqrt(3), math.Pi/4, math.Acos(1/math.Sqrt(3)))
 	}
 }
 

--- a/opencv/cxcore_test.go
+++ b/opencv/cxcore_test.go
@@ -3,6 +3,7 @@ package opencv
 import (
 	"bytes"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"os"
 	"path"
@@ -345,5 +346,82 @@ func TestLogic(t *testing.T) {
 	// 0 = 1 ^ 1
 	XorScalarWithMask(oneImg, one, outImg, maskImg)
 	checkValsWMask(outImg, maskImg, 0, "XorScalarWithMask()")
+}
 
+func TestPointRadiusAngleHelpers(t *testing.T) {
+
+	// test Point
+	testPoint := func(p PointIntrfc, rad, az, inc float64) {
+		if p.Radius() != rad {
+			t.Errorf("%v, Radius() Fail: Expected: %f, Received: %f", p, rad, p.Radius())
+		}
+		if p.Angle() != az {
+			t.Errorf("%v, Angle() Fail: Expected: %f, Received: %f", p, az, p.Angle())
+		}
+		if p.IncAngle() != inc {
+			t.Errorf("%v, IncAngle() Fail: Expected: %f, Received: %f", p, inc, p.IncAngle())
+		}
+	}
+
+	zeroOneTests := []PointIntrfc{
+		Point{0, 1},
+		Point2D32f{0, 1},
+		Point2D64f{0, 1},
+		Point3D32f{0, 1, 0},
+		Point3D64f{0, 1, 0},
+	}
+
+	for _, zeroOne := range zeroOneTests {
+		testPoint(
+			zeroOne,
+			1,         // radius should be 1
+			math.Pi/2, // angle should be pi/2
+			math.Pi/2, // inc angle should also be pi/2
+		)
+	}
+
+	fiveFiveTests := []PointIntrfc{
+		Point{5, 5},
+		Point2D32f{5, 5},
+		Point2D64f{5, 5},
+		Point3D32f{5, 5, 0},
+		Point3D64f{5, 5, 0},
+	}
+	for _, fiveFive := range fiveFiveTests {
+		testPoint(
+			fiveFive,
+			math.Sqrt(50), // radius
+			math.Pi/4,     // angle
+			math.Pi/2,     // inc angle
+		)
+	}
+
+	negThreeFourTests := []PointIntrfc{
+		Point{-3, 4},
+		Point2D32f{-3, 4},
+		Point2D64f{-3, 4},
+		Point3D32f{-3, 4, 0},
+		Point3D64f{-3, 4, 0},
+	}
+	for _, negThreeFour := range negThreeFourTests {
+		testPoint(
+			negThreeFour,
+			5, // radius
+			math.Pi-math.Atan(4.0/3.0), // az angle
+			math.Pi/2,                  // inc angle
+		)
+	}
+
+	oneOneOneTests := []PointIntrfc{
+		Point3D32f{1, 1, 1},
+		Point3D64f{1, 1, 1},
+	}
+	for _, oneoneone := range oneOneOneTests {
+		testPoint(
+			oneoneone,
+			math.Sqrt(3),              // radius
+			math.Pi/4,                 // az angle
+			math.Acos(1/math.Sqrt(3)), // inc angle
+		)
+	}
 }

--- a/opencv/cxtype.go
+++ b/opencv/cxtype.go
@@ -58,6 +58,7 @@ static int myGetTermCriteriaType(const CvTermCriteria* x) {
 */
 import "C"
 import (
+	"math"
 	"unsafe"
 )
 
@@ -552,29 +553,169 @@ func (x *TermCriteria) Epsilon() float64 {
 
 /******************************* CvPoint and variants ***********************************/
 
+/************************************* Point *******************************************/
+
 type Point struct {
 	X int
 	Y int
 }
 
+func (p *Point) Add(p2 Point) {
+	p.X += p2.X
+	p.Y += p2.Y
+}
+
+func (p *Point) Sub(p2 Point) {
+	p.X -= p2.X
+	p.Y -= p2.Y
+}
+
+func (p *Point) Radius() float64 {
+	return math.Sqrt(p.RadiusSq())
+}
+
+func (p *Point) RadiusSq() float64 {
+	return float64(p.X*p.X + p.Y*p.Y)
+}
+
+func (p *Point) Angle() float64 {
+	return math.Atan2(float64(p.Y), float64(p.X))
+}
+
+/************************************* Point2D32f **************************************/
+
 type Point2D32f struct {
 	X float32
 	Y float32
 }
+
+func (p *Point2D32f) Add(p2 Point2D32f) {
+	p.X += p2.X
+	p.Y += p2.Y
+}
+
+func (p *Point2D32f) Sub(p2 Point2D32f) {
+	p.X -= p2.X
+	p.Y -= p2.Y
+}
+
+func (p *Point2D32f) Radius() float64 {
+	return math.Sqrt(p.RadiusSq())
+}
+
+func (p *Point2D32f) RadiusSq() float64 {
+	return float64(p.X*p.X + p.Y*p.Y)
+}
+
+func (p *Point2D32f) Angle() float64 {
+	return math.Atan2(float64(p.Y), float64(p.X))
+}
+
+/************************************* Point3D32f **************************************/
+
 type Point3D32f struct {
 	X float32
 	Y float32
 	Z float32
 }
 
+func (p *Point3D32f) Add(p2 Point3D32f) {
+	p.X += p2.X
+	p.Y += p2.Y
+	p.Z += p2.Z
+}
+
+func (p *Point3D32f) Sub(p2 Point3D32f) {
+	p.X -= p2.X
+	p.Y -= p2.Y
+	p.Z -= p2.Z
+}
+
+func (p *Point3D32f) Radius() float64 {
+	return math.Sqrt(p.RadiusSq())
+}
+
+func (p *Point3D32f) RadiusSq() float64 {
+	return float64(p.X*p.X + p.Y*p.Y + p.Z*p.Z)
+}
+
+func (p *Point3D32f) IncAngle() float64 {
+	if p.Radius() == 0 {
+		return 0
+	}
+	return math.Acos(float64(p.Z) / p.Radius())
+}
+
+func (p *Point3D32f) AzAngle() float64 {
+	return math.Atan2(float64(p.Y), float64(p.X))
+}
+
+/************************************* Point2D64f **************************************/
+
 type Point2D64f struct {
 	X float64
 	Y float64
 }
+
+func (p *Point2D64f) Add(p2 Point2D64f) {
+	p.X += p2.X
+	p.Y += p2.Y
+}
+
+func (p *Point2D64f) Sub(p2 Point2D64f) {
+	p.X -= p2.X
+	p.Y -= p2.Y
+}
+
+func (p *Point2D64f) Radius() float64 {
+	return math.Sqrt(p.RadiusSq())
+}
+
+func (p *Point2D64f) RadiusSq() float64 {
+	return p.X*p.X + p.Y*p.Y
+}
+
+func (p *Point2D64f) Angle() float64 {
+	return math.Atan2(p.Y, p.X)
+}
+
+/************************************* Point3D64f **************************************/
+
 type Point3D64f struct {
 	X float64
 	Y float64
 	Z float64
+}
+
+func (p *Point3D64f) Add(p2 Point3D64f) {
+	p.X += p2.X
+	p.Y += p2.Y
+	p.Z += p2.Z
+}
+
+func (p *Point3D64f) Sub(p2 Point3D64f) {
+	p.X -= p2.X
+	p.Y -= p2.Y
+	p.Z -= p2.Z
+}
+
+func (p *Point3D64f) Radius() float64 {
+	return math.Sqrt(p.RadiusSq())
+}
+
+func (p *Point3D64f) RadiusSq() float64 {
+	return p.X*p.X + p.Y*p.Y + p.Z*p.Z
+}
+
+func (p *Point3D64f) IncAngle() float64 {
+	if p.Radius() == 0 {
+		return 0
+	}
+	return math.Acos(p.Z / p.Radius())
+}
+
+func (p *Point3D64f) AzAngle() float64 {
+	return math.Atan2(p.Y, p.X)
 }
 
 /******************************** CvSize's & CvBox **************************************/

--- a/opencv/cxtype.go
+++ b/opencv/cxtype.go
@@ -553,11 +553,25 @@ func (x *TermCriteria) Epsilon() float64 {
 
 /******************************* CvPoint and variants ***********************************/
 
+/********************************* Point Interface **************************************/
+
+type PointIntrfc interface {
+	Radius() float64   // the radius to the point
+	RadiusSq() float64 // the radius to the point squared
+	Angle() float64    // the azmuith angle
+	IncAngle() float64 // the inclination angle from the z direction
+	ToPoint() Point    // An conversion to a 2D integer Point
+}
+
 /************************************* Point *******************************************/
 
 type Point struct {
 	X int
 	Y int
+}
+
+func (p Point) ToPoint() Point {
+	return p
 }
 
 func (p *Point) Add(p2 Point) {
@@ -570,23 +584,29 @@ func (p *Point) Sub(p2 Point) {
 	p.Y -= p2.Y
 }
 
-func (p *Point) Radius() float64 {
+func (p Point) Radius() float64 {
 	return math.Sqrt(p.RadiusSq())
 }
 
-func (p *Point) RadiusSq() float64 {
+func (p Point) RadiusSq() float64 {
 	return float64(p.X*p.X + p.Y*p.Y)
 }
 
-func (p *Point) Angle() float64 {
+func (p Point) Angle() float64 {
 	return math.Atan2(float64(p.Y), float64(p.X))
 }
+
+func (p Point) IncAngle() float64 { return math.Pi / 2 }
 
 /************************************* Point2D32f **************************************/
 
 type Point2D32f struct {
 	X float32
 	Y float32
+}
+
+func (p Point2D32f) ToPoint() Point {
+	return Point{int(p.X), int(p.Y)}
 }
 
 func (p *Point2D32f) Add(p2 Point2D32f) {
@@ -599,17 +619,19 @@ func (p *Point2D32f) Sub(p2 Point2D32f) {
 	p.Y -= p2.Y
 }
 
-func (p *Point2D32f) Radius() float64 {
+func (p Point2D32f) Radius() float64 {
 	return math.Sqrt(p.RadiusSq())
 }
 
-func (p *Point2D32f) RadiusSq() float64 {
+func (p Point2D32f) RadiusSq() float64 {
 	return float64(p.X*p.X + p.Y*p.Y)
 }
 
-func (p *Point2D32f) Angle() float64 {
+func (p Point2D32f) Angle() float64 {
 	return math.Atan2(float64(p.Y), float64(p.X))
 }
+
+func (p Point2D32f) IncAngle() float64 { return math.Pi / 2 }
 
 /************************************* Point3D32f **************************************/
 
@@ -617,6 +639,10 @@ type Point3D32f struct {
 	X float32
 	Y float32
 	Z float32
+}
+
+func (p Point3D32f) ToPoint() Point {
+	return Point{int(p.X), int(p.Y)} // ignores Z
 }
 
 func (p *Point3D32f) Add(p2 Point3D32f) {
@@ -631,23 +657,23 @@ func (p *Point3D32f) Sub(p2 Point3D32f) {
 	p.Z -= p2.Z
 }
 
-func (p *Point3D32f) Radius() float64 {
+func (p Point3D32f) Radius() float64 {
 	return math.Sqrt(p.RadiusSq())
 }
 
-func (p *Point3D32f) RadiusSq() float64 {
+func (p Point3D32f) RadiusSq() float64 {
 	return float64(p.X*p.X + p.Y*p.Y + p.Z*p.Z)
 }
 
-func (p *Point3D32f) IncAngle() float64 {
+func (p Point3D32f) Angle() float64 {
+	return math.Atan2(float64(p.Y), float64(p.X))
+}
+
+func (p Point3D32f) IncAngle() float64 {
 	if p.Radius() == 0 {
 		return 0
 	}
 	return math.Acos(float64(p.Z) / p.Radius())
-}
-
-func (p *Point3D32f) AzAngle() float64 {
-	return math.Atan2(float64(p.Y), float64(p.X))
 }
 
 /************************************* Point2D64f **************************************/
@@ -655,6 +681,10 @@ func (p *Point3D32f) AzAngle() float64 {
 type Point2D64f struct {
 	X float64
 	Y float64
+}
+
+func (p Point2D64f) ToPoint() Point {
+	return Point{int(p.X), int(p.Y)}
 }
 
 func (p *Point2D64f) Add(p2 Point2D64f) {
@@ -667,17 +697,19 @@ func (p *Point2D64f) Sub(p2 Point2D64f) {
 	p.Y -= p2.Y
 }
 
-func (p *Point2D64f) Radius() float64 {
+func (p Point2D64f) Radius() float64 {
 	return math.Sqrt(p.RadiusSq())
 }
 
-func (p *Point2D64f) RadiusSq() float64 {
+func (p Point2D64f) RadiusSq() float64 {
 	return p.X*p.X + p.Y*p.Y
 }
 
-func (p *Point2D64f) Angle() float64 {
+func (p Point2D64f) Angle() float64 {
 	return math.Atan2(p.Y, p.X)
 }
+
+func (p Point2D64f) IncAngle() float64 { return math.Pi / 2 }
 
 /************************************* Point3D64f **************************************/
 
@@ -685,6 +717,10 @@ type Point3D64f struct {
 	X float64
 	Y float64
 	Z float64
+}
+
+func (p Point3D64f) ToPoint() Point {
+	return Point{int(p.X), int(p.Y)} // ignores Z
 }
 
 func (p *Point3D64f) Add(p2 Point3D64f) {
@@ -699,23 +735,23 @@ func (p *Point3D64f) Sub(p2 Point3D64f) {
 	p.Z -= p2.Z
 }
 
-func (p *Point3D64f) Radius() float64 {
+func (p Point3D64f) Radius() float64 {
 	return math.Sqrt(p.RadiusSq())
 }
 
-func (p *Point3D64f) RadiusSq() float64 {
+func (p Point3D64f) RadiusSq() float64 {
 	return p.X*p.X + p.Y*p.Y + p.Z*p.Z
 }
 
-func (p *Point3D64f) IncAngle() float64 {
+func (p Point3D64f) Angle() float64 {
+	return math.Atan2(p.Y, p.X)
+}
+
+func (p Point3D64f) IncAngle() float64 {
 	if p.Radius() == 0 {
 		return 0
 	}
 	return math.Acos(p.Z / p.Radius())
-}
-
-func (p *Point3D64f) AzAngle() float64 {
-	return math.Atan2(p.Y, p.X)
 }
 
 /******************************** CvSize's & CvBox **************************************/

--- a/opencv/cxtype.go
+++ b/opencv/cxtype.go
@@ -553,14 +553,20 @@ func (x *TermCriteria) Epsilon() float64 {
 
 /******************************* CvPoint and variants ***********************************/
 
-/********************************* Point Interface **************************************/
+/********************************* Point Interfaces *************************************/
 
-type PointIntrfc interface {
+type Point2D interface {
 	Radius() float64   // the radius to the point
 	RadiusSq() float64 // the radius to the point squared
 	Angle() float64    // the azmuith angle
+	ToPoint() Point    // An conversion to an integer Point type
+}
+
+type Point3D interface {
+	Radius() float64   // the radius to the point
+	RadiusSq() float64 // the radius to the point squared
+	AzAngle() float64  // the azmuith angle
 	IncAngle() float64 // the inclination angle from the z direction
-	ToPoint() Point    // An conversion to a 2D integer Point
 }
 
 /************************************* Point *******************************************/
@@ -596,8 +602,6 @@ func (p Point) Angle() float64 {
 	return math.Atan2(float64(p.Y), float64(p.X))
 }
 
-func (p Point) IncAngle() float64 { return math.Pi / 2 }
-
 /************************************* Point2D32f **************************************/
 
 type Point2D32f struct {
@@ -631,18 +635,12 @@ func (p Point2D32f) Angle() float64 {
 	return math.Atan2(float64(p.Y), float64(p.X))
 }
 
-func (p Point2D32f) IncAngle() float64 { return math.Pi / 2 }
-
 /************************************* Point3D32f **************************************/
 
 type Point3D32f struct {
 	X float32
 	Y float32
 	Z float32
-}
-
-func (p Point3D32f) ToPoint() Point {
-	return Point{int(p.X), int(p.Y)} // ignores Z
 }
 
 func (p *Point3D32f) Add(p2 Point3D32f) {
@@ -665,7 +663,7 @@ func (p Point3D32f) RadiusSq() float64 {
 	return float64(p.X*p.X + p.Y*p.Y + p.Z*p.Z)
 }
 
-func (p Point3D32f) Angle() float64 {
+func (p Point3D32f) AzAngle() float64 {
 	return math.Atan2(float64(p.Y), float64(p.X))
 }
 
@@ -709,18 +707,12 @@ func (p Point2D64f) Angle() float64 {
 	return math.Atan2(p.Y, p.X)
 }
 
-func (p Point2D64f) IncAngle() float64 { return math.Pi / 2 }
-
 /************************************* Point3D64f **************************************/
 
 type Point3D64f struct {
 	X float64
 	Y float64
 	Z float64
-}
-
-func (p Point3D64f) ToPoint() Point {
-	return Point{int(p.X), int(p.Y)} // ignores Z
 }
 
 func (p *Point3D64f) Add(p2 Point3D64f) {
@@ -743,7 +735,7 @@ func (p Point3D64f) RadiusSq() float64 {
 	return p.X*p.X + p.Y*p.Y + p.Z*p.Z
 }
 
-func (p Point3D64f) Angle() float64 {
+func (p Point3D64f) AzAngle() float64 {
 	return math.Atan2(p.Y, p.X)
 }
 


### PR DESCRIPTION
I needed some `Point` struct helper routines and I was going to do it in a separate library, but then I thought it might be more useful (for me and possibly others) if I added it to this one.
Here are the main features:

1. You can now add and subtract points from one another.
2. Any of the floating-point point types can be converted easily back to the default integer type.
3. There are now methods for converting to polar/spherical coordinates.
