### PR TITLE
params is an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ func main() {
 	resized1 := opencv.Resize(srcImg, 400, 0, 0)
 	resized2 := opencv.Resize(srcImg, 300, 500, 0)
 	resized3 := opencv.Resize(srcImg, 300, 500, 2)
-	opencv.SaveImage("resized1.jpg", resized1, 0)
-	opencv.SaveImage("resized2.jpg", resized2, 0)
-	opencv.SaveImage("resized3.jpg", resized3, 0)
+	opencv.SaveImage("resized1.jpg", resized1, nil)
+	opencv.SaveImage("resized2.jpg", resized2, nil)
+	opencv.SaveImage("resized3.jpg", resized3, nil)
 }
 ```
 

--- a/opencv/cxcore_test.go
+++ b/opencv/cxcore_test.go
@@ -51,13 +51,13 @@ func TestPutText(t *testing.T) {
 	// Uncomment this code to create the test image "../images/pic3_with_text.jpg"
 	// It is part of the repo, and what this test compares against
 	//
-	// SaveImage(filename, image, 0)
+	// SaveImage(filename, image, nil)
 	// println("Saved file", filename)
 
 	tempfilename := path.Join(os.TempDir(), "pic3_with_text.png")
 	defer syscall.Unlink(tempfilename)
 
-	SaveImage(tempfilename, image, 0)
+	SaveImage(tempfilename, image, nil)
 
 	// Compare actual image with expected image
 	same, err := BinaryCompare(filename, tempfilename)
@@ -181,10 +181,10 @@ func TestAddSub(t *testing.T) {
 	checkValsWMask(t, negImage, nil, 0, "SubScalarRev()")
 
 	// Uncomment to save these images to disk
-	// SaveImage("zeroImg.png", zeroImg, CV_IMWRITE_PNG_COMPRESSION)
-	// SaveImage("hundredImg.png", hundredImg, CV_IMWRITE_PNG_COMPRESSION)
-	// SaveImage("twoHundredImg.png", twoHundredImg, CV_IMWRITE_PNG_COMPRESSION)
-	// SaveImage("negImage.png", negImage, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("zeroImg.png", zeroImg, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
+	// SaveImage("hundredImg.png", hundredImg, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
+	// SaveImage("twoHundredImg.png", twoHundredImg, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
+	// SaveImage("negImage.png", negImage, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
 
 }
 
@@ -232,11 +232,11 @@ func TestAddSubWithMask(t *testing.T) {
 	checkValsWMask(t, negImage, maskImg, 0, "SubScalarWithMaskRev()")
 
 	// Uncomment to save these images to disk
-	// SaveImage("zeroImgMask.png", zeroImg, CV_IMWRITE_PNG_COMPRESSION)
-	// SaveImage("hundredImgMask.png", hundredImg, CV_IMWRITE_PNG_COMPRESSION)
-	// SaveImage("twoHundredImgMask.png", twoHundredImg, CV_IMWRITE_PNG_COMPRESSION)
-	// SaveImage("negImageMask.png", negImage, CV_IMWRITE_PNG_COMPRESSION)
-	// SaveImage("MaskImg.png", maskImg, CV_IMWRITE_PNG_COMPRESSION)
+	// SaveImage("zeroImgMask.png", zeroImg, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
+	// SaveImage("hundredImgMask.png", hundredImg, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
+	// SaveImage("twoHundredImgMask.png", twoHundredImg, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
+	// SaveImage("negImageMask.png", negImage, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
+	// SaveImage("MaskImg.png", maskImg, []int{CV_IMWRITE_PNG_COMPRESSION, 3})
 
 }
 

--- a/opencv/highgui.go
+++ b/opencv/highgui.go
@@ -391,11 +391,14 @@ const (
 )
 
 /* save image to file */
-func SaveImage(filename string, image *IplImage, params int) int {
+func SaveImage(filename string, image *IplImage, params []int) int {
 	name_c := C.CString(filename)
 	defer C.free(unsafe.Pointer(name_c))
-	params_c := C.int(params)
-	rv := C.cvSaveImage(name_c, unsafe.Pointer(image), &params_c)
+	params_c := make([]C.int, 0)
+	for _, param := range params {
+		params_c = append(params_c, C.int(param))
+	}
+	rv := C.cvSaveImage(name_c, unsafe.Pointer(image), &params_c[0])
 	return int(rv)
 }
 
@@ -410,12 +413,15 @@ func DecodeImageM(buf unsafe.Pointer, iscolor int) *Mat {
 }
 
 /* encode image and store the result as a byte vector (single-row 8uC1 matrix) */
-func EncodeImage(ext string, image unsafe.Pointer, params int) *Mat {
-	params_c := C.int(params)
+func EncodeImage(ext string, image unsafe.Pointer, params []int) *Mat {
+	params_c := make([]C.int, 0)
+	for _, param := range params {
+		params_c = append(params_c, C.int(param))
+	}
 	ext_c := C.CString(ext)
 	defer C.free(unsafe.Pointer(ext_c))
 
-	rv := C.cvEncodeImage(ext_c, (image), &params_c)
+	rv := C.cvEncodeImage(ext_c, (image), &params_c[0])
 	return (*Mat)(rv)
 }
 

--- a/opencv/highgui.go
+++ b/opencv/highgui.go
@@ -394,11 +394,15 @@ const (
 func SaveImage(filename string, image *IplImage, params []int) int {
 	name_c := C.CString(filename)
 	defer C.free(unsafe.Pointer(name_c))
-	params_c := make([]C.int, 0)
-	for _, param := range params {
-		params_c = append(params_c, C.int(param))
+	var firstParam *C.int
+	if len(params) > 0 {
+		var params_c []C.int
+		for _, param := range params {
+			params_c = append(params_c, C.int(param))
+		}
+		firstParam = &params_c[0]
 	}
-	rv := C.cvSaveImage(name_c, unsafe.Pointer(image), &params_c[0])
+	rv := C.cvSaveImage(name_c, unsafe.Pointer(image), firstParam)
 	return int(rv)
 }
 
@@ -414,14 +418,18 @@ func DecodeImageM(buf unsafe.Pointer, iscolor int) *Mat {
 
 /* encode image and store the result as a byte vector (single-row 8uC1 matrix) */
 func EncodeImage(ext string, image unsafe.Pointer, params []int) *Mat {
-	params_c := make([]C.int, 0)
-	for _, param := range params {
-		params_c = append(params_c, C.int(param))
+	var firstParam *C.int
+	if len(params) > 0 {
+		var params_c []C.int
+		for _, param := range params {
+			params_c = append(params_c, C.int(param))
+		}
+		firstParam = &params_c[0]
 	}
 	ext_c := C.CString(ext)
 	defer C.free(unsafe.Pointer(ext_c))
 
-	rv := C.cvEncodeImage(ext_c, (image), &params_c[0])
+	rv := C.cvEncodeImage(ext_c, (image), firstParam)
 	return (*Mat)(rv)
 }
 

--- a/opencv/imgproc_test.go
+++ b/opencv/imgproc_test.go
@@ -94,11 +94,11 @@ func TestFindContours(t *testing.T) {
 	// Uncomment this code to create the test image "../images/shapes_contours.png"
 	// It is part of the repo, and what this test compares against
 	//
-	//SaveImage(filename), contours, 0)
+	//SaveImage(filename), contours, nil)
 
 	tempfilename := path.Join(os.TempDir(), "pic5_contours.png")
 	defer syscall.Unlink(tempfilename)
-	SaveImage(tempfilename, contours, 0)
+	SaveImage(tempfilename, contours, nil)
 
 	// Compare actual image with expected image
 	same, err := BinaryCompare(filename, tempfilename)

--- a/samples/crop.go
+++ b/samples/crop.go
@@ -22,7 +22,7 @@ func main() {
 	defer image.Release()
 
 	crop := opencv.Crop(image, 0, 0, 50, 50)
-	opencv.SaveImage("/tmp/crop.jpg", crop, 0)
+	opencv.SaveImage("/tmp/crop.jpg", crop, nil)
 	crop.Release()
 
 	os.Exit(0)


### PR DESCRIPTION
params is supposed to be pairs of settings

http://docs.opencv.org/2.4/modules/highgui/doc/reading_and_writing_images_and_video.html#bool%20imwrite(const%20string&%20filename,%20InputArray%20img,%20const%20vector%3Cint%3E&%20params)

This bug has been pointed out already, perhaps 6 months ago https://github.com/lazywei/go-opencv/issues/68

You might as well just fix it. It'll break some programs, but they were unable to use this anyway. Might be useful to bump the version.