### PR TITLE
Fixed index out of range panic when channels==4 in ToImage function

### DIFF
--- a/opencv/goimage.go
+++ b/opencv/goimage.go
@@ -73,14 +73,14 @@ func (img *IplImage) ToImage() image.Image {
 	c := color.NRGBA{R: uint8(0), G: uint8(0), B: uint8(0), A: uint8(255)}
 	// Iteratively assign imageData's color to Go's image
 	for y := 0; y < height; y++ {
-		for x := 0; x < step; x = x + 3 {
+		for x := 0; x < step; x = x + channels {
 			c.B = uint8(data[y*step+x])
 			c.G = uint8(data[y*step+x+1])
 			c.R = uint8(data[y*step+x+2])
 			if channels == 4 {
 				c.A = uint8(data[y*step+x+3])
 			}
-			out.SetNRGBA(int(x/3), y, c)
+			out.SetNRGBA(int(x/channels), y, c)
 		}
 	}
 


### PR DESCRIPTION
In the `ToImage` function, if the `channels` variable was `4` then the function would throw an index out of range error.

Consider the case in which `channels == 4`, but the increment is `x=x+3`:

* Iteration `0`:
```
y = 0
x = 0
step = 1000 # made up for the example 
c.B = 0
c.G = 1
c.R = 2
c.A = 3
```
* Iteration `1`:
If `x = x+3`, then you end up overwriting the `B` channel from the previous iteration:
```
y = 0
x = 3
step = 1000
c.B = 3
c.G = 4
c.R = 5
c.A = 6
```
However, if the increment is `x = x+4`:
```
y = 0
x = 4
step = 1000
c.B = 5
c.G = 6
c.R = 7
c.A = 8
```

This PR ensures that there are not out of range errors by setting the increment to `channels`.